### PR TITLE
feat: add clocks to evaluation bars

### DIFF
--- a/src/app/evalbars/App.js
+++ b/src/app/evalbars/App.js
@@ -330,10 +330,13 @@ function App() {
       clocks = clocks.map(clock => {return clock.split(" ")[1].split("]")[0]});
 
       // get time control of the game
-      const timeControl = specificGamePgn.match(/\[TimeControl "(.*?)"\]/)[1];
-      let time = timeControl.split(":")[0].split("+")[0];
-      if (time.includes("/")) {
-        time = Number(time.split("/")[1]);
+      let time = 0;
+      if (specificGamePgn.match(/\[TimeControl "(.*?)"\]/)) {        
+        const timeControl = specificGamePgn.match(/\[TimeControl "(.*?)"\]/)[1];
+        time = timeControl.split(":")[0].split("+")[0];
+        if (time.includes("/")) {
+          time = Number(time.split("/")[1]);
+        }
       }
 
       const convertClockToSeconds = (clock) => {


### PR DESCRIPTION
Note: Clocks are based on the clock value of the last move. Timer for clocks are started once the evalbar is mounted or a move is made. So, if an evalbar is mounted some time after last move was made, there will be delay in actual timer and evalbar clock. This issue will be fixed automatically after the next move.