### PR TITLE
feat: add move number and turn indicator

### DIFF
--- a/src/app/evalbars/App.js
+++ b/src/app/evalbars/App.js
@@ -252,9 +252,10 @@ function App() {
             blackPlayer,
             error: null,
             lastFEN: "",
-            whitetime: 0,
+            whiteTime: 0,
             blackTime: 0,
             turn: "",
+            moveNumber: 0,
           },
         ]);
         updateEvaluationsForLink({ whitePlayer, blackPlayer });
@@ -366,6 +367,9 @@ function App() {
         turn = "black";
       }
 
+      // move number of player for the current turn
+      const moveNumber = Math.floor(clocks.length/2)+1;
+
       let gameResult = null;
       const resultMatch = cleanedPgn.match(/(1-0|0-1|1\/2-1\/2)$/);
       if (resultMatch) {
@@ -390,6 +394,7 @@ function App() {
             whiteTime,
             blackTime,
             turn,
+            moveNumber,
           };
         }
       } catch (error) {
@@ -631,6 +636,7 @@ function App() {
                 whiteTime={link.whiteTime}
                 blackTime={link.blackTime}
                 turn={link.turn}
+                moveNumber={link.moveNumber}
               />
             ))}
           </Box>

--- a/src/components/evalbar/Evalbar.js
+++ b/src/components/evalbar/Evalbar.js
@@ -72,8 +72,8 @@ function EvalBar({
   // adjusts the time passed after the last move
   useEffect(() => {
     clearInterval(intervalRef.current);
-    setTimePassed(0);
     if (turn !== "" && !result) {
+      setTimePassed(0);
       intervalRef.current = setInterval(() => {
         setTimePassed(prevValue => prevValue+1);
       },1000);

--- a/src/components/evalbar/Evalbar.js
+++ b/src/components/evalbar/Evalbar.js
@@ -17,6 +17,7 @@ function EvalBar({
   whiteTime,
   blackTime,
   turn,
+  moveNumber,
 }) {
   const prevEvaluationRef = useRef(null);
   const prevResultRef = useRef(undefined);
@@ -207,15 +208,16 @@ function EvalBar({
         className="player-names"
         display="flex"
         justifyContent="space-between"
+        alignItems="center"
         style={{ marginBottom: "1px" }} // Add a small margin at the bottom
       >
-        {/*clock's color turns red when the clock reaches 30 seconds otherwise if it is the player's turn it turns lightgreen else color stays as player name color*/}
+        {/*clock's color turns red when the clock reaches 30 seconds otherwise if it stays as player name color*/}
         <Typography
           variant="h6"
           className="white-player"
           style={{
             background: customStyles.whitePlayerColor,
-            color: turn === "white" ? whiteTime - timePassed <= 30 ? "red" : "lightgreen" : whiteTime <= 30 ? "red" : customStyles.whitePlayerNameColor,
+            color: (turn === "white" && whiteTime - timePassed <= 30) || whiteTime <= 30 ? "red" : customStyles.whitePlayerNameColor,
             fontSize: "0.8rem",
             padding: "2px 8px", // Reduced vertical padding
             maxWidth: "45%",
@@ -229,12 +231,44 @@ function EvalBar({
             }
           </b>
         </Typography>
+        {/*Left arrow (white turn indicator)*/}
+        <div
+          style={{
+            border: "5px solid transparent",
+            borderRight: "7px solid orange",
+            borderLeftWidth: "0px",
+            opacity: turn === "white" ? 1 : 0.5
+          }}
+        >
+        </div>
+        {/*Move number of player (current turn)*/}
+        <Typography
+          variant="h6"
+          style={{
+            background: customStyles.whitePlayerColor,
+            color: "white",
+            fontSize: "0.8rem",
+            padding: "2px", // Reduced vertical padding
+          }}
+        >
+          <b>{moveNumber}</b>
+        </Typography>
+        {/*Right arrow (black turn indicator)*/}
+        <div
+          style={{
+            border: "5px solid transparent",
+            borderLeft: "7px solid orange",
+            borderRightWidth: "0px",
+            opacity: turn === "black" ? 1 : 0.5
+          }}
+        >
+        </div>
         <Typography
           variant="h6"
           className="black-player"
           style={{
             background: customStyles.blackPlayerColor,
-            color: turn === "black" ? blackTime - timePassed <= 30 ? "red" : "lightgreen" : blackTime <= 30 ? "red" : customStyles.blackPlayerNameColor,
+            color: (turn === "black" && blackTime - timePassed <= 30) || blackTime <= 30 ? "red" : customStyles.blackPlayerNameColor,
             fontSize: "0.8rem",
             padding: "2px 8px", // Reduced vertical padding
             maxWidth: "45%",


### PR DESCRIPTION
Details:
1. Added move number (move that is about to make) for the player at the turn.
2. Added turn indicator.
3. Removed "lightgreen" color for the clocks which showcase the turns. This is redundant because of the explicit turn indicator. Also for some reason "lightgreen" color isn't visible in chessbase india's stream.

Screenshot:
![eval bar](https://github.com/user-attachments/assets/587b2524-d8f3-4cde-a6c5-4e302d25b098)

Message:
Apologies, I couldn't add the screenshot for previous PR. Thank you Rakshit for accepting the previous PR. Thank you Sagar bhai for the shoutout. These are all the changes I wanted to see in the evaluation bars, so I worked on them. If I get any more ideas I will add them, but I doubt there any more changes needed or even good justification for increase in space.