### PR TITLE
feat: UI and design changes

### DIFF
--- a/src/app/evalbars/App.js
+++ b/src/app/evalbars/App.js
@@ -699,38 +699,42 @@ function App() {
                   marginBottom: 2,
                 }}
               >
-                {availableGames.map((game, index) => (
-                  <GameCard
-                    key={index}
-                    game={game}
-                    onClick={() => handleGameSelection(game)}
-                    isSelected={selectedGames.includes(game)}
-                  />
-                ))}
-                <Button
-                  variant="contained"
-                  color="primary"
-                  style={{ marginTop: "10px", marginRight: "10px" }}
-                  onClick={addSelectedGames}
-                >
-                  Add Selected Games Bar
-                </Button>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  style={{ marginTop: "10px", marginRight: "10px" }}
-                  onClick={handleDemoBlunder}
-                >
-                  Demo Blunder
-                </Button>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  style={{ marginTop: "10px" }}
-                  onClick={handleGenerateLink}
-                >
-                  Create Unique Link
-                </Button>
+                <Box>
+                  {availableGames.map((game, index) => (
+                    <GameCard
+                      key={index}
+                      game={game}
+                      onClick={() => handleGameSelection(game)}
+                      isSelected={selectedGames.includes(game)}
+                    />
+                  ))}
+                </Box>
+                <Box mb={2}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    style={{ marginTop: "10px", marginRight: "10px" }}
+                    onClick={addSelectedGames}
+                  >
+                    Add Selected Games Bar
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    style={{ marginTop: "10px", marginRight: "10px" }}
+                    onClick={handleDemoBlunder}
+                  >
+                    Demo Blunder
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    style={{ marginTop: "10px" }}
+                    onClick={handleGenerateLink}
+                  >
+                    Create Unique Link
+                  </Button>
+                </Box>
                 <CustomizeEvalBar
                   customStyles={customStyles}
                   setCustomStyles={setCustomStyles}

--- a/src/app/evalbars/App.js
+++ b/src/app/evalbars/App.js
@@ -193,6 +193,13 @@ function App() {
     }
   };
 
+  const returnToHomePage = () => {
+    if (isBroadcastLoaded) {
+      setIsBroadcastLoaded(false);
+      setLinks([]);
+    }
+  }
+
   const startStreaming = async (roundId) => {
     if (!roundId) {
       console.error("No roundId provided for streaming");
@@ -676,7 +683,8 @@ function App() {
                 <img
                   src="https://i.imgur.com/z2fbMtT.png"
                   alt="ChessBase India Logo"
-                  style={{ height: "100px", marginTop: "20px" }}
+                  style={{ height: "100px", marginTop: "20px", cursor: isBroadcastLoaded ? "pointer" : "default" }}
+                  onClick={returnToHomePage}
                 />
               </Box>
             </Toolbar>

--- a/src/components/evalbar/Evalbar.js
+++ b/src/components/evalbar/Evalbar.js
@@ -133,7 +133,7 @@ function EvalBar({
 
   const formatEvaluation = (evalValue) => {
     if (evalValue < -1000 || evalValue > 1000) {
-      return "Checkmate";
+      return "Winning";
     }
     return evalValue;
   };

--- a/src/components/tournaments-list/TournamentsList.js
+++ b/src/components/tournaments-list/TournamentsList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 
 const TournamentsWrapper = styled.div`
@@ -6,10 +6,6 @@ const TournamentsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-const NoBroadcastsMessage = styled.p`
-  color: #faf9f6; /* White color */
-  font-size: 1.2em; /* Bigger font size */
 `;
 
 const Card = styled.div`
@@ -21,7 +17,6 @@ const Card = styled.div`
   padding: 1rem;
   margin: 1rem 0;
   border-radius: 1rem;
-  cursor: pointer;
   background-color: ${(props) =>
     props.selected ? "rgba(76, 175, 80, 0.3)" : "rgba(1, 1, 4, 0.6)"};
   transition: all 0.3s ease-in-out;
@@ -51,12 +46,14 @@ const CardHeader = styled.div`
 const CardTitle = styled.h2`
   font-size: 1.8em;
   color: #faf9f6;
+  margin-top: 1rem;
   margin-bottom: 1rem;
 `;
 
 const CardDate = styled.p`
   font-size: 1em;
   color: #faf9f6;
+  margin-top: 1rem;
   margin-bottom: 1rem;
 `;
 
@@ -102,7 +99,7 @@ const Title = styled.h1`
 const SearchWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 `;
 
 const SearchInput = styled.input`
@@ -129,11 +126,8 @@ const TournamentsList = ({ onSelect }) => {
   const [tournaments, setTournaments] = useState([]);
   const [filteredTournaments, setFilteredTournaments] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedTournaments, setSelectedTournaments] = useState([]);
-  const [checkedItems, setCheckedItems] = useState({});
   const [customUrl, setCustomUrl] = useState("");
   const [tournamentId, setTournamentId] = useState("");
-  const [broadcasts, setBroadcasts] = useState(true);
 
   useEffect(() => {
     fetch("https://lichess.org/api/broadcast?nb=50")
@@ -150,9 +144,6 @@ const TournamentsList = ({ onSelect }) => {
         );
         setTournaments(ongoingTournaments);
         setFilteredTournaments(ongoingTournaments);
-        if (ongoingTournaments.length === 0) {
-          setBroadcasts(false);
-        }
       })
       .catch((error) =>
         console.error("Error fetching tournaments:", error)
@@ -203,7 +194,9 @@ const TournamentsList = ({ onSelect }) => {
           placeholder="Search tournaments..."
         />
         <SearchButton onClick={handleSearch}>Search</SearchButton>
+      </SearchWrapper>
 
+      <SearchWrapper>
         <SearchInput
           value={customUrl}
           onChange={handleCustomUrlChange}
@@ -215,7 +208,6 @@ const TournamentsList = ({ onSelect }) => {
         tournament.tour && tournament.rounds && tournament.rounds.length > 0 ? (
           <Card
             key={tournament.tour.id}
-            selected={selectedTournaments.includes(tournament.tour.id)}
           >
             {tournament.image && (
               <img
@@ -224,26 +216,6 @@ const TournamentsList = ({ onSelect }) => {
                 alt="Tournament Image"
               />
             )}
-            <input
-              type="checkbox"
-              checked={checkedItems[tournament.tour.id]}
-              onChange={() => {
-                setCheckedItems((prevState) => ({
-                  ...prevState,
-                  [tournament.tour.id]: !prevState[tournament.tour.id],
-                }));
-                const ongoingRound = tournament.rounds.find(
-                  (round) => round.ongoing === true
-                ) || tournament.rounds[0];
-                if (ongoingRound) {
-                  onSelect({
-                    tournamentId: tournament.tour.id,
-                    roundId: ongoingRound.id,
-                    gameIDs: ongoingRound.games ? ongoingRound.games.map(game => `${game.white.name}-vs-${game.black.name}`) : []
-                  });
-                }
-              }}
-            />
             <CardHeader>
               <CardTitle>{tournament.tour.name}</CardTitle>
               <CardDate>{tournament.tour.date}</CardDate>

--- a/src/components/tournaments-list/TournamentsList.js
+++ b/src/components/tournaments-list/TournamentsList.js
@@ -64,7 +64,7 @@ const CardDescription = styled.p`
   font-size: 1em;
   color: #faf9f6;
   margin-bottom: 1rem;
-  height: 4em;
+  height: auto;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
@@ -243,7 +243,7 @@ const TournamentsList = ({ onSelect }) => {
               <CardTitle>{tournament.tour.name}</CardTitle>
               <CardDate>{tournament.tour.date}</CardDate>
             </CardHeader>
-            <CardDescription>{tournament.tour.description}</CardDescription>
+            <CardDescription>{tournament.tour.description ?? "No description available"}</CardDescription>
             <Button
               href={tournament.tour.url}
               target="_blank"

--- a/src/components/tournaments-list/TournamentsList.js
+++ b/src/components/tournaments-list/TournamentsList.js
@@ -69,8 +69,13 @@ const CardDescription = styled.p`
   text-overflow: ellipsis;
 `;
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 const Button = styled.a`
-  margin-top: 0.5rem;
+  margin: 0.5rem;
   padding: 0.5rem 1rem;
   background-color: #4caf50;
   color: white;
@@ -244,13 +249,31 @@ const TournamentsList = ({ onSelect }) => {
               <CardDate>{tournament.tour.date}</CardDate>
             </CardHeader>
             <CardDescription>{tournament.tour.description ?? "No description available"}</CardDescription>
-            <Button
-              href={tournament.tour.url}
-              target="_blank"
-              rel="noreferrer"
-            >
-              Official Website
-            </Button>
+            <ButtonWrapper>
+              <Button
+                onClick={() => {
+                  const ongoingRound = tournament.rounds.find(
+                    (round) => round.ongoing === true
+                  ) || tournament.rounds[0];
+                  if (ongoingRound) {
+                    onSelect({
+                      tournamentId: tournament.tour.id,
+                      roundId: ongoingRound.id,
+                      gameIDs: ongoingRound.games ? ongoingRound.games.map(game => `${game.white.name}-vs-${game.black.name}`) : []
+                    });
+                  }
+                }}
+              >
+                Check Games
+              </Button>
+              <Button
+                href={tournament.tour.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Official Website
+              </Button>
+            </ButtonWrapper>
           </Card>
         ) : null
       )}


### PR DESCRIPTION
This PR is mostly focused on UI and design changes for the website. The final evaluation bar is not changed and is displayed similar as before.

Changes:

- Added "No description available" placeholder when there is no description present for a tournament. Changed the height of description text to "auto" as the cards are taking a fixed height even when the description is not present. This also helps with larger descriptions.
- Added "button wrapper" to hold all the buttons for a tournament. Added "Check Games" button inside "button wrapper" to be used as navigation button to "broadcast page" instead of checkbox.
- I didn't understand the reason for using checkbox as an input to navigate to a page. I removed this checkbox as it can be added later if a potential new feature is required (multiple tournaments selection). I cleaned up unused code in the "TournamentList" file. I adjusted the styling for list items and search items.
- There is no way to return to the tournament list page from broadcast page. I added the onClick function to the logo such that it renders tournament list page when present in broadcast page.
- Added separation of games and setting options in broadcast page.
- When result is not declared (meaning game is still ongoing), then the evaluation should never show checkmate. When evaluation is too high in favor of a player, then it should considered as winning. Changed evaluation text from "Checkmate" to "Winning" in this scenario.